### PR TITLE
🏠 Change The Base Directory to `~/.minibot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A snappy, CPU-friendly chatbot that learns from your Q&A and responds in real-time! Built with Python, MiniBot uses Sentence Transformers for embeddings and cosine similarity to find the best match.
 
----
-
 ## 🌟 Features
 
 - **🧠 Self-learning:** Learns new Q&A on the fly and stores them in `qa.csv`.
@@ -11,8 +9,6 @@ A snappy, CPU-friendly chatbot that learns from your Q&A and responds in real-ti
 - **💾 Cached model:** Downloads once from Hugging Face, loads instantly after.
 - **🧩 Expandable:** Add more Q&A to boost its brainpower.
 - **🧘 CPU-friendly:** Runs smoothly on laptops—no GPU needed!
-
----
 
 ## ⚙️ Installation
 
@@ -31,8 +27,6 @@ pip install pandas scikit-learn pyttsx3 sentence-transformers numpy
 
 > 💡 **Note:** CPU-friendly version. No TensorFlow or GPU required.
 
----
-
 ## 💬 Usage
 
 - Make sure `qa.csv` exists (MiniBot will create it if missing).
@@ -43,15 +37,14 @@ pip install pandas scikit-learn pyttsx3 sentence-transformers numpy
   ```
 
 - Chat with MiniBot!
+
   - Type a question and wait for a response.
   - If MiniBot doesn’t know the answer, it will ask you to teach it:
-    - **MiniBot:** I don't know, can you teach me? 
+    - **MiniBot:** I don't know, can you teach me?
     - **You (teach MiniBot):** [Type your answer here]
     - MiniBot will remember it for next time.
 
 - Type `.exit` or `.quit` to close the chatbot.
-
----
 
 ## 🧪 How It Works
 
@@ -61,24 +54,26 @@ pip install pandas scikit-learn pyttsx3 sentence-transformers numpy
 4. If similarity < 0.4, it asks you to teach it.
 5. Saves new Q&A and updates embeddings dynamically.
 
----
-
 ## 🧾 Example
 
 ```
-You: Hello
-MiniBot: Hi there!
+You » Hello
 
-You: Who is Trump?
-MiniBot: I don't know, can you teach me? 
-You (teach MiniBot): Donald Trump is the 47th president of the USA
-MiniBot: Got it! I'll remember that.
+MiniBot » Hi there!
 
-You: Who is Trump?
-MiniBot: Donald Trump is the 47th president of the USA
+You » Who is Trump?
+
+MiniBot » I don't know, can you teach me?
+
+You (teach MiniBot)
+∘ Donald Trump is the 47th president of the USA
+
+MiniBot » Got it! I'll remember that.
+
+You » Who is Trump?
+
+MiniBot » Donald Trump is the 47th president of the USA
 ```
-
----
 
 ## 📦 Dependencies
 
@@ -88,14 +83,10 @@ MiniBot: Donald Trump is the 47th president of the USA
 - sentence-transformers
 - numpy
 
----
-
 ## 📜 License
 
 MIT License — see [LICENSE](LICENSE) for details.  
 Feel free to fork, remix, and contribute! 🛠️
-
----
 
 ## 📝 Notes
 

--- a/index.py
+++ b/index.py
@@ -18,14 +18,19 @@ def speak(text):
         engine.say(sentence)
     engine.runAndWait()
 
-cache_path = os.path.join(os.getcwd(), "MinibotModelCache")
+home_dir = os.path.expanduser('~')
+minibot_dir = os.path.join(home_dir, '.minibot')
+os.makedirs(minibot_dir, exist_ok=True)
+
+cache_path = os.path.join(minibot_dir, 'MinibotModelCache')
 model = SentenceTransformer('all-MiniLM-L6-v2', cache_folder=cache_path)
 
+qa_path = os.path.join(minibot_dir, 'qa.csv')
 try:
-    data = pd.read_csv("qa.csv")
+    data = pd.read_csv(qa_path)
 except FileNotFoundError:
     data = pd.DataFrame(columns=["question","response"])
-    data.to_csv("qa.csv", index=False)
+    data.to_csv(qa_path, index=False)
 
 if len(data) > 0:
     embeddings = model.encode(data["question"].tolist(), show_progress_bar=False).tolist()
@@ -70,7 +75,7 @@ while True:
         if new_answer:
             new_row = pd.DataFrame([[user, new_answer]], columns=["question","response"])
             data = pd.concat([data, new_row], ignore_index=True)
-            data.to_csv("qa.csv", index=False)
+            data.to_csv(qa_path, index=False)
             embeddings.append(model.encode([user])[0].tolist())
             print(minibot_prompt + white_color + "Got it! I'll remember that.")
             speak("Got it! I'll remember that.")


### PR DESCRIPTION
Change the base directory to `~/minibot` instead of current dir, now the data lies in `~/.minibot/qa.csv` and `~/.minibot/MinibotModelCache`

The main reason for doing this is:

- if the user runs `index.py` alone (without the current dir)
- if the user moves the `index.py` file to other place
- if run from `minibot.exe` (minibot converted to `.exe` and moved to `Program Files` folder or sth)
